### PR TITLE
broaden nether portal trap check

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -759,7 +759,8 @@ class PlayerEventHandler implements Listener
         if(returnLocation != null)
         {
             PlayerEventHandler.portalReturnMap.remove(player.getUniqueId());
-            if(player.getLocation().getBlock().getType() == Material.PORTAL)
+			Block playerBlock = player.getLocation().getBlock();
+			if(playerBlock.getType() == Material.PORTAL || isInNonOccludingBlock(playerBlock))
             {
                 player.teleport(returnLocation);
             }
@@ -781,7 +782,28 @@ class PlayerEventHandler implements Listener
             }
         }
 	}
-	
+
+	boolean isInNonOccludingBlock(Block block)
+	{
+		Material playerBlock = block.getType();
+		//Most blocks you can "stand" inside but cannot pass through (isSolid) usually can be seen through (!isOccluding)
+		//This can cause players to technically be considered not in a portal block, yet in reality is still stuck in the portal animation.
+		if ((!playerBlock.isSolid() || playerBlock.isOccluding())) //If it is _not_ such a block,
+		{
+			//Check the block above
+			playerBlock = block.getRelative(BlockFace.UP).getType();
+			if ((!playerBlock.isSolid() || playerBlock.isOccluding()))
+				return false; //player is not stuck
+		}
+		//Check if this block is also adjacent to a portal
+		if (block.getRelative(BlockFace.EAST).getType() == Material.PORTAL
+				|| block.getRelative(BlockFace.WEST).getType() == Material.PORTAL
+				|| block.getRelative(BlockFace.NORTH).getType() == Material.PORTAL
+				|| block.getRelative(BlockFace.SOUTH).getType() == Material.PORTAL)
+			return true;
+		return false;
+	}
+
 	//when a player spawns, conditionally apply temporary pvp protection 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.MONITOR)
     void onPlayerRespawn (PlayerRespawnEvent event)


### PR DESCRIPTION
## Issue
Players can be considered to be inside solid blocks that are non-occluding, such as fence blocks or iron bars. When these blocks are used as a "gate" for a nether portal, the player, according to CB/the server, can actually be within the fence block, even though the player is still experiencing the nether portal animation.

This poses a problem with the current nether portal trap check, as it only checks if the player is within a portal block.

## Proposed Solution
This PR extends the nether portal trap check to see if the player is in (or the block above is) a solid, non-occluding block. If so, it will check if this block is adjacent to a portal block to determine if the player is trapped.

### Potential improvements
If you're aware of a cheaper/better way to check adjacent blocks, let me know.
