### PR TITLE
Fix sign logging/spam detection

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
+++ b/src/me/ryanhamshire/GriefPrevention/BlockEventHandler.java
@@ -131,7 +131,7 @@ public class BlockEventHandler implements Listener
 		
 		//if not empty and wasn't the same as the last sign, log it and remember it for later
 		PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
-		if(notEmpty && playerData.lastSignMessage != null && !playerData.lastSignMessage.equals(signMessage))
+		if(notEmpty && (playerData.lastSignMessage == null || !playerData.lastSignMessage.equals(signMessage)))
 		{		
 			GriefPrevention.AddLogEntry(player.getName() + lines.toString().replace("\n  ", ";"), null);
 			PlayerEventHandler.makeSocialLogEntry(player.getName(), signMessage);


### PR DESCRIPTION
I'd also like an option to remove the repeated sign placement "protection" as I've observed legitimate players place duplicate signs at times.