### PR TITLE
Add admin command to unlock the drops of other players.

### DIFF
--- a/src/me/ryanhamshire/GriefPrevention/DataStore.java
+++ b/src/me/ryanhamshire/GriefPrevention/DataStore.java
@@ -1557,6 +1557,7 @@ public abstract class DataStore
 		this.addDefault(defaults, Messages.DropUnlockAdvertisement, "Other players can't pick up your dropped items unless you /UnlockDrops first.", null);
 		this.addDefault(defaults, Messages.PickupBlockedExplanation, "You can't pick this up unless {0} uses /UnlockDrops.", "0: The item stack's owner.");
 		this.addDefault(defaults, Messages.DropUnlockConfirmation, "Unlocked your drops.  Other players may now pick them up (until you die again).", null);
+		this.addDefault(defaults, Messages.DropUnlockOthersConfirmation, "Unlocked {0}'s drops.", "0: The owner of the unlocked drops.");
 		this.addDefault(defaults, Messages.AdvertiseACandACB, "You may use /ACB to give yourself more claim blocks, or /AdminClaims to create a free administrative claim.", null);
 		this.addDefault(defaults, Messages.AdvertiseAdminClaims, "You could create an administrative land claim instead using /AdminClaims, which you'd share with other administrators.", null);
 		this.addDefault(defaults, Messages.AdvertiseACB, "You may use /ACB to give yourself more claim blocks.", null);

--- a/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -2131,9 +2131,27 @@ public class GriefPrevention extends JavaPlugin
 		//unlockItems
 		else if(cmd.getName().equalsIgnoreCase("unlockdrops") && player != null)
 		{
-			PlayerData playerData = this.dataStore.getPlayerData(player.getUniqueId());
+			PlayerData playerData;
+
+			if (player.hasPermission("griefprevention.unlockothersdrops") && args.length == 1)
+			{
+				Player otherPlayer = Bukkit.getPlayer(args[0]);
+				if (otherPlayer == null)
+				{
+					GriefPrevention.sendMessage(player, TextMode.Err, Messages.PlayerNotFound2);
+					return true;
+				}
+
+				playerData = this.dataStore.getPlayerData(otherPlayer.getUniqueId());
+				GriefPrevention.sendMessage(player, TextMode.Success, Messages.DropUnlockOthersConfirmation, otherPlayer.getName());
+			}
+			else
+			{
+				playerData = this.dataStore.getPlayerData(player.getUniqueId());
+				GriefPrevention.sendMessage(player, TextMode.Success, Messages.DropUnlockConfirmation);
+			}
+
 		    playerData.dropsAreUnlocked = true;
-		    GriefPrevention.sendMessage(player, TextMode.Success, Messages.DropUnlockConfirmation);
 			
 			return true;
 		}

--- a/src/me/ryanhamshire/GriefPrevention/Messages.java
+++ b/src/me/ryanhamshire/GriefPrevention/Messages.java
@@ -187,6 +187,7 @@ public enum Messages
     DropUnlockAdvertisement,
     PickupBlockedExplanation,
     DropUnlockConfirmation,
+    DropUnlockOthersConfirmation,
     AdvertiseACandACB,
     AdvertiseAdminClaims,
     AdvertiseACB,


### PR DESCRIPTION
Once in a while we've had trouble with people dying while AFK. Since we enabled the locking of dropped items (in order to prevent other- harder to fix- issues), we've been unable to help the players out by storing their items in a safe place for when they return.

I made this as a solution for my server, but I figured I might as well offer to have it included upstream.

Let me know if you'd like anything changed.